### PR TITLE
fix: fix positioning

### DIFF
--- a/src/PulsatingCircle.vue
+++ b/src/PulsatingCircle.vue
@@ -72,27 +72,22 @@ export default class PulsatingCircleIcon extends Vue {
     }
   }
 
-  position: absolute;
-  left: 50%;
-  top: 50%;
   transform: translateX(-50%) translateY(-50%);
 
   .pulse {
     position: relative;
     display: block;
-    width: 250%;
-    height: 250%;
+    width: 200%;
+    height: 200%;
     box-sizing: border-box;
-    margin-left: -75%;
-    margin-top: -75%;
     border-radius: 50%;
     animation: pulse 1.25s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
   }
 
   .circle {
     position: absolute;
-    left: 0;
-    top: 0;
+    left: 50%;
+    top: 50%;
     display: block;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Fix positioning by removing the `absolute` position of the outer div of the `PulsatingCircle` which caused the circles to align to the next relative div from where it is implemented.

The outer div of the `PulsatingCircle` is now relative to contain the circles inside it and to keep the correct dimensions of the whole component.

BREAKING CHANGE: positioning and size changed

Positioning has been changed from "absolute" to "relative", which is why spacing may have to be adjusted.

The size of the pulse slightly changed from `250%` to `200%`.